### PR TITLE
Add junction to control flow.  Fixes #28.

### DIFF
--- a/src/clj/lambdacd/internal/execution.clj
+++ b/src/clj/lambdacd/internal/execution.clj
@@ -92,7 +92,7 @@
 (defn- to-context-and-step [ctx step-results-channel]
   (fn [idx step]
     (let [parent-step-id (:step-id ctx)
-          new-step-id (cons (inc idx) parent-step-id)
+          new-step-id (step-id/child-id parent-step-id (inc idx))
           step-ctx (assoc ctx :step-id new-step-id
                               :step-results-channel step-results-channel)]
     [step-ctx step])))

--- a/src/clj/lambdacd/internal/step_id.clj
+++ b/src/clj/lambdacd/internal/step_id.clj
@@ -24,3 +24,6 @@
   (and
     (not (= a b))
     (not (later-than? a b))))
+
+(defn child-id [parent-step-id child-number]
+  (cons child-number parent-step-id))


### PR DESCRIPTION
This fixes #28. Instead of a checkpoint that stops the pipeline, this gives the possibility to fork into two pipeline branches:

```clojure
(junction 
    conditional-step 
    success-step 
    failiure-step)
```

To realise the checkpoint idea, success-step could just contain (run) which stops the pipeline gracefully.