### PR TITLE
Add a repo-branch argument to with-git which gets the latest revision…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lambdacd "0.5.4-SNAPSHOT"
+(defproject lambdacd "0.5.3-SNAPSHOT"
   :description "a library to create a continous delivery pipeline in code"
   :url "http://github.com/flosell/lambdacd"
   :license {:name "Apache License, version 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lambdacd "0.5.3-SNAPSHOT"
+(defproject lambdacd "0.5.4-SNAPSHOT"
   :description "a library to create a continous delivery pipeline in code"
   :url "http://github.com/flosell/lambdacd"
   :license {:name "Apache License, version 2.0"

--- a/src/clj/lambdacd/steps/git.clj
+++ b/src/clj/lambdacd/steps/git.clj
@@ -107,10 +107,14 @@
 
 (defn with-git
   "creates a container-step that checks out a given revision from a repository.
-   the revision number is passed on as the :revision value in the arguments-map"
-  [repo-uri steps]
-  (fn [args ctx]
-    (checkout-and-execute repo-uri (:revision args) args ctx steps)))
+   the revision number is passed on as the :revision value in the arguments-map or,
+   if a repo-branch is supplied, the current revision of the branch given is passed on."
+  ([repo-uri steps]
+   (fn [args ctx]
+     (checkout-and-execute repo-uri (:revision args) args ctx steps)))
+  ([repo-uri repo-branch steps]
+   (fn [args ctx]
+     (checkout-and-execute repo-uri (:revision (current-revision repo-uri repo-branch)) args ctx steps))))
 
 (defn- parse-log-lines [l]
   (let [[hash & msg-parts] (s/split l #" ")

--- a/src/clj/lambdacd/steps/git.clj
+++ b/src/clj/lambdacd/steps/git.clj
@@ -107,14 +107,17 @@
 
 (defn with-git
   "creates a container-step that checks out a given revision from a repository.
-   the revision number is passed on as the :revision value in the arguments-map or,
-   if a repo-branch is supplied, the current revision of the branch given is passed on."
-  ([repo-uri steps]
-   (fn [args ctx]
-     (checkout-and-execute repo-uri (:revision args) args ctx steps)))
-  ([repo-uri repo-branch steps]
-   (fn [args ctx]
-     (checkout-and-execute repo-uri (:revision (current-revision repo-uri repo-branch)) args ctx steps))))
+   the revision number is passed on as the :revision value in the arguments-map"
+  [repo-uri steps]
+  (fn [args ctx]
+    (checkout-and-execute repo-uri (:revision args) args ctx steps)))
+
+(defn with-git-branch
+  "creates a container-step that checks out the latest revision from a repository with the
+  given branch."
+  [repo-uri repo-branch steps]
+  (fn [args ctx]
+    (checkout-and-execute repo-uri repo-branch args ctx steps)))
 
 (defn- parse-log-lines [l]
   (let [[hash & msg-parts] (s/split l #" ")


### PR DESCRIPTION
… of the given branch and passes it on. This is useful for those using Gitflow because it is more common to checkout the develop branch instead of the master branch. 