### PR TITLE
fixed merging of step results 

### DIFF
--- a/src/clj/lambdacd/internal/execution.clj
+++ b/src/clj/lambdacd/internal/execution.clj
@@ -121,7 +121,8 @@
 (defn- merge-entry [r1 r2]
   (cond
     (keyword? r1) (merge-status r1 r2)
-    (coll? r1) (into r1 r2)
+    (and (coll? r1) (coll? r2)) (into r1 r2)
+    (coll? r1) (merge r1 r2)
     :else r2))
 
 (defn merge-two-step-results [r1 r2]

--- a/src/clj/lambdacd/internal/execution.clj
+++ b/src/clj/lambdacd/internal/execution.clj
@@ -121,7 +121,7 @@
 (defn- merge-entry [r1 r2]
   (cond
     (keyword? r1) (merge-status r1 r2)
-    (coll? r1) (merge r1 r2)
+    (coll? r1) (into r1 r2)
     :else r2))
 
 (defn merge-two-step-results [r1 r2]

--- a/test/clj/lambdacd/steps/support_test.clj
+++ b/test/clj/lambdacd/steps/support_test.clj
@@ -250,13 +250,14 @@
     (is (= { } (merge-step-results [{} {}]))))
   (testing "that later step-results overwrite earlier ones"
     (is (= {:foo :baz} (merge-step-results [{:foo :bar} {:foo :baz}]))))
+  (testing "that details are merged correctly"
+    (is (= {:a [{:b 2} {:c 3}]} (merge-step-results [{:a [{:b 2}]} {:a [{:c 3}]}]))))
   (testing "that there is a special status handling"
     (is (= {:status :success} (merge-step-results [{:status :success} {:status :success}])))
     (is (= {:status :failure} (merge-step-results [{:status :success} {:status :failure}])))
     (is (= {:status :unknown} (merge-step-results [{:status :unknown} {:status :success}]))) ; non-success trumps order
     (is (= {:status :unknown} (merge-step-results [{:status :failure} {:status :unknown}]))) ; non-success overwrites in order
     (is (= {:status :failure} (merge-step-results [{:status :failure} {:status :success}]))))) ; non-success trumps order
-
 
 (deftest capture-output-test
   (testing "that the original step result is kept"


### PR DESCRIPTION
… when the values in the maps to be merged are seqs
before the fix merging steps resulted in 
`"status": "success",
  "details": [
    {
      "label": "foo"
    },
    [
      {
        "label": "bar"
      }
    ]
  ],` 

now it should return the expected 
`"status": "success",
  "details": [
    {
      "label": "foo"
    },
      {
        "label": "bar"
      }
  ],`