### PR TITLE
use clojure.test/function? instead of is-fn? hack

### DIFF
--- a/test/clj/lambdacd/presentation/pipeline_structure_test.clj
+++ b/test/clj/lambdacd/presentation/pipeline_structure_test.clj
@@ -87,6 +87,9 @@
       (is (= :unknown (display-type (second (second (first pipeline)))))))
     (testing "that nil is an unknown type"
       (is (= :unknown (display-type nil))))
+    (testing "that bool is an unknown type"
+      (is (= :unknown (display-type true)))
+      (is (= :unknown (display-type false))))
     (testing "that a sequence with child-steps is a container"
       (is (= :container (display-type `(do-stuff do-more-stuff))))
       (is (= :container (display-type simple-pipeline))))


### PR DESCRIPTION
There was a bug in pipeline-structure which lead to exceptions when trying to use **boolean** values in the pipeline structure. I added a test case for this.
Instead of adding another line to the `is-fn?` or expression, I replaced it's usage with `clojure.test/function?`, which does exactly what `is-fn?` is supposed to. If you have reservations about using code from the test namespace, copying or re-creating that function would also work.
I applied auto-formatting to the changed file as well.