### PR TITLE
Increase buffers to decrease deadlock probability

### DIFF
--- a/src/clj/lambdacd/util.clj
+++ b/src/clj/lambdacd/util.clj
@@ -79,7 +79,7 @@
   (ch/generate-string v))
 
 (defn buffered [ch]
-  (let [result-ch (async/chan 100)]
+  (let [result-ch (async/chan 1000)]
     (async/pipe ch result-ch)))
 
 (defn json [data]

--- a/test/clj/lambdacd/deadlock/deadlock_pipe.clj
+++ b/test/clj/lambdacd/deadlock/deadlock_pipe.clj
@@ -1,0 +1,102 @@
+(ns lambdacd.deadlock.deadlock-pipe
+  (:use [clojure.test])
+  (:require [lambdacd.steps.support :as support]
+            [lambdacd.steps.control-flow :refer [in-parallel]]
+            [lambdacd.execution :as exec]
+            [lambdacd.util :as util]
+            [clojure.core.async :as as]))
+
+(def bacon-ipsum "Bacon ipsum dolor amet meatloaf tongue flank biltong ground round. Sirloin venison sausage kielbasa andouille strip steak tri-tip. Meatloaf biltong capicola shoulder. Sausage shankle pancetta prosciutto porchetta short loin.\n\n")
+
+(defn print-1000-lines-in-clj [args ctx]
+  (let [out-ch (:result-channel ctx)]
+    (support/capture-output ctx
+                            (doseq [i (range 1 1000)]
+                              (do
+                                (println i ")" bacon-ipsum)
+                                )))
+    {:status :success}))
+
+(defn done-step [args ctx]
+  (println "Done")
+  {:status :success}
+  )
+
+(def pipeline-def
+  `(
+     (in-parallel
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj
+       print-1000-lines-in-clj)
+     done-step
+     )
+
+  )
+
+(deftest deadlock-test
+  (testing "should not end in a deadlock"
+    (let [home-dir (util/create-temp-dir)
+          config {:home-dir             home-dir
+                  :name                 "deadlock pipeline"
+                  :step-updates-per-sec 10}
+          pipeline (lambdacd.core/assemble-pipeline pipeline-def config)
+          sub (lambdacd.event-bus/subscribe (:context pipeline) :step-finished)
+          count-finished (atom 0)
+          ]
+      (println @count-finished)
+      (as/go-loop []
+        (as/<! sub)
+        (swap! count-finished inc)
+        (recur))
+
+      (exec/run (:pipeline-def pipeline) (:context pipeline))
+
+      (println @count-finished)
+
+      ))
+
+  )


### PR DESCRIPTION
In our pipelines we are experiencing further deadlocks, especially when multiple builds a running and /or there are a lot of build-steps running in-parallel.

With an artificial setup, I can reproduce a deadlock situation, even when `:step-updates-per-sec` is down to `1`. One solution seems to be increasing the buffer size of the `pipeline-state-update`. 