### PR TITLE
bump VM image to 20.04 to have recent nodejs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: focal # run the build on ubuntu 20.04 for a recent nodejs version
+
 before_script:
   - ./scripts/travis_prebuild.sh
   - ./go deps


### PR DESCRIPTION
Hello @flosell,

your last build broke because npm requires an more recent nodejs version. This comes with a more recent ubuntu build VM. So I bumped it from 16.04 to 20.04
I couldn't verify that this fixes the problem though, because there is another build dependency missing: javasysmon
```Could not transfer artifact com.jezhumble:javasysmon:pom:0.3.6 from/to gocd (https://dl.bintray.com/gocd-maven-repo/generic/gocd): Access denied to: https://dl.bintray.com/gocd-maven-repo/generic/gocd/com/jezhumble/javasysmon/0.3.6/javasysmon-0.3.6.pom , ReasonPhrase:Forbidden.```
See #203 for that issue.