### PR TITLE
replace javasysmon dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: focal # run the build on ubuntu 20.04 for a recent nodejs version
+
 before_script:
   - ./scripts/travis_prebuild.sh
   - ./go deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog contains a loose collection of changes in every release. I will a
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to a "shifted" version of semantic versioning while the major version remains at 0: Minor version changes indicate breaking changes, patch version changes should not contain breaking changes.
 
+## 0.14.6
+
+### Fixed
+
+* Replace javasysmon dependency with the one from com.danielflower which is on maven central. 0.3.6 has been deleted from gocd's bintray repo
+
 ## 0.14.5 
 
 ### Security

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,6 @@
   :min-lein-version "2.5.0"
   :deploy-repositories [["clojars" {:creds :gpg}]
                         ["releases" :clojars]]
-  :repositories [["gocd" "https://dl.bintray.com/gocd-maven-repo/generic/gocd"]] ; for jezhumbles javasysmon
   :source-paths ["src/clj" "src/cljs"]
   :test-paths ["test/clj" "example/clj"]
   :jar-exclusions [#"logback.xml"]
@@ -30,7 +29,7 @@
                  [cheshire "5.4.0"]
                  [cljsjs/moment "2.22.2-0"]
                  [clj-time "0.9.0"]
-                 [com.jezhumble/javasysmon "0.3.6"]
+                 [com.danielflower.apprunner/javasysmon  "0.3.5.1"]
                  [clj-timeframes "0.1.0"]]
   ; excluding a few transitive dependencies:
   ; process-tree-killer depends on this for windows only and doesnt provide it...


### PR DESCRIPTION
replace javasysmon dependency with one available on mvn central to get the build running again. Fixes #203

I had a look at the corresponding repo at https://github.com/danielflower/javasysmon and they look fine to me.
If you are comfortable with this as well, please merge this PR.

I also tried to get the new ProcessHandle API working but had no luck with that, my Clojure is too weak :/